### PR TITLE
refactor: graft directories, include readme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-recursive-include script *.py
-recursive-include base *.h *.cpp *.cxx
-recursive-include swig *.h *.cpp
+include README.md
+graft script
+graft base
+graft swig


### PR DESCRIPTION
A suggestion to use `graft` to include whole directory trees and to include the readme in the source distribution.