### PR TITLE
fix: git submodule should be fetched recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to to build the python package, you will have to check out the reposito
 
 	git clone https://github.com/sbmlteam/python-libsbml
 	cd python-libsbml
-	git submodule update --init
+	git submodule update --init --recursive
 
 By default, we track the latest release of the [libSBML](https://github.com/sbmlteam/libsbml) project via submodule in `libsbml_source` the version number is also read from the `VERSION.txt`
 file from the submodule. So if another version of libSBML should be built, the submodule has to 


### PR DESCRIPTION
## What I did
FIx the build command from `git submodule update --init` to `git submodule update --init --recursive`.
If recursive flag is not provided, got this error on M4 Mac.

```bash
arm64 -DCMAKE_INSTALL_PREFIX=/Users/araki/research/master2/autolayout/smartgd/python-libsbml/install_dependencies_macosx-15.0-arm64 -DWITH_BZIP2=ON
  -DWITH_CHECK=OFF -DWITH_EXPAT=ON -DWITH_XERCES=OFF -DWITH_ICONV=OFF -DWITH_LIBXML=OFF
  -- The C compiler identification is AppleClang 16.0.0.16000026
  -- The CXX compiler identification is AppleClang 16.0.0.16000026
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  CMake Error at CMakeLists.txt:155 (add_subdirectory):
    add_subdirectory given source "expat/expat" which is not an existing
    directory.


  CMake Error at CMakeLists.txt:158 (set_target_properties):
    set_target_properties Can not find target to add properties to: expat


  --   Building universal binaries               = yes (using arm64)
  -- Configuring incomplete, errors occurred!
  error: command '/Users/araki/research/master2/autolayout/smartgd/python-libsbml/venv/bin/cmake' failed with exit code 1
```

My fixture resolve all this, and I got success to build.