### PR TITLE
feat: add description how to install the package into the venv, add s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,27 @@ updated. For example manually like so to follow the latest development:
 Building the package
 ------------
 Once those steps are done, the library can be build using the `setup.py` script.
+If you want to create virtual environment on other directory, not equal python-libsbml, you need to set SWIG_EXECUTABLE environment variable.
 
-	python setup.py build
+    python -m venv /path/to/your/venv
+
+    source /path/to/your/venv/bin/activate
+
+    pip install --upgrade pip setuptools wheel cmake swig
+
+	export SWIG_EXECUTABLE=$(which swig) && python setup.py build
 
 to build the experimental package, all that needs to be done is to set the environment variable `LIBSBML_EXPERIMENTAL=1` prior to building
+
+Install the package into the virtual environment:
+------------
+This is main part of the process, you can install the build package into the virtual environment using the following command:
+
+    source /path/to/your/venv/bin/activate # Activate the virtual environment
+
+    python setup.py bdist_wheel
+
+    pip install dist/python_libsbml-*.whl
 
 ⁇ Getting Help
 ------------


### PR DESCRIPTION
## What I did
When build source with virtual environment that creates on not python-libsbml directory, if we do not set SWIG_EXECUTABLE environment variable, build failed on my M4 Mac.
So I added that knowledge and the way to install `python-libsbml` package into user's virtual environment.

## Related PR
https://github.com/sbmlteam/python-libsbml/pull/42